### PR TITLE
Read qq acquisition datetime from the report

### DIFF
--- a/qpu_monitoring/qpu_monitoring/metrics_export.py
+++ b/qpu_monitoring/qpu_monitoring/metrics_export.py
@@ -22,7 +22,11 @@ def from_path(json_path: Path):
 @dataclass
 class QpuData:
     qubit_metrics: list[dict[str, Any]]
+    """List of metrics acquired using qibocal.
+    Its shape is equal to the number of quit of the platform.
+    Each element of the list contains a dictionary with acquired data."""
     acquisition_time: dt.datetime = field(default_factory=dt.datetime.now)
+    """Date and time of the qibocal acquisition."""
 
 
 def get_data(qibocal_output_folder: Path) -> QpuData:


### PR DESCRIPTION
The purpose of this PR is to read the acquisition date and time from qibocal's report. This way we can also upload older reports to the db.