### PR TITLE
DB schema initial draft

### DIFF
--- a/qpu_monitoring/qpu_monitoring/add_platform.py
+++ b/qpu_monitoring/qpu_monitoring/add_platform.py
@@ -1,0 +1,26 @@
+from qibolab import create_platform
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from qpu_monitoring.database_schema import QPU
+from qpu_monitoring.metrics_export import postgres_url
+
+
+def add_platform(platform: str, qpu_name=None, **kwargs):
+    """Adds a Qibolab platform to the Postgres DB"""
+    if qpu_name is None:
+        qpu_name = platform
+
+    qibolab_platform = create_platform(platform)
+    engine = create_engine(
+        postgres_url(**kwargs),
+        echo=True,
+    )
+    with Session(engine) as session:
+        qpu = QPU(
+            name=qpu_name,
+            nqubits=qibolab_platform.nqubits,
+            topology=[e for e in qibolab_platform.topology.edges],
+        )
+        session.add(qpu)
+        session.commit()

--- a/qpu_monitoring/qpu_monitoring/database_schema.py
+++ b/qpu_monitoring/qpu_monitoring/database_schema.py
@@ -1,7 +1,10 @@
 import datetime as dt
+from typing import List, Tuple
 
-from sqlalchemy import DateTime
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 
@@ -9,27 +12,66 @@ class Base(DeclarativeBase):
     pass
 
 
-class Qubit(Base):
-    __tablename__ = "qubit"
+class QPU(Base):
+    __tablename__ = "qpu"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    """Primary key."""
+    name: Mapped[str] = mapped_column(String(50), unique=True)
+    """Platform name"""
+    nqubits: Mapped[int]
+    """Number of qubits for chip"""
+    topology: Mapped[List[Tuple[int]]] = mapped_column(ARRAY(Integer, dimensions=2))
+    """QPU topology"""
+
+
+class BaseCharacterizationData(Base):
+    __abstract__ = True
 
     id: Mapped[int] = mapped_column(primary_key=True)
     """Primary key."""
     qubit_id: Mapped[int]
     """Qubit id."""
-    qpu_name: Mapped[str]
-    """QPU name."""
+    qpu_id: Mapped[int] = mapped_column(ForeignKey("qpu.id"))
+    """QPU id."""
+
+    @declared_attr
+    def qpu(self):
+        return relationship("QPU")
+
+    """QPU object"""
+    acquisition_time: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+    """Time when metrics are acquired."""
+
+    @declared_attr
+    def __mapper_args__(cls):
+        if cls.__name__ == "BaseCharacterizationData":
+            return {
+                "polymorphic_identity": "BaseCharacterizationData",
+                "polymorphic_on": cls.type,
+            }
+        else:
+            return {"polymorphic_identity": cls.__name__}
+
+    def __str__(self) -> str:
+        return f"Qubit(id={self.id}, qubit_id={self.qubit_id}, qpu_name={self.qpu.name}, time={self.acquisition_time})"
+
+
+class CoherenceTime(BaseCharacterizationData):
+    __tablename__ = "coherence_time"
+
     t1: Mapped[float]
     """Qubit t1 in ns."""
     t2: Mapped[float]
     """Qubit t2 in ns."""
     # t2_spin_echo: Mapped[float]
     # """Qubit t2 spin echo in ns."""
+
+
+class AssignmentFidelity(BaseCharacterizationData):
+    __tablename__ = "assignment_fidelity"
+
     assignment_fidelity: Mapped[float]
     """Qubit assignment fidelity in the range [0,1]."""
-    acquisition_time: Mapped[dt.datetime] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
-    )
-    """Time when metrics are acquired."""
-
-    def __str__(self) -> str:
-        return f"Qubit(id={self.id}, qubit_id={self.qubit_id}, qpu_name={self.qpu_name}, time={self.acquisition_time})"


### PR DESCRIPTION
The general idea of this proposed schema is to have a central table `qpu` listing the available platforms and separate tables for every Qibocal characterization runcard that we will be routinely performing.

The rationale is that each runcard will have its own frequency due to the difference in runtime. For example, to measure the T1/T2 of the QPU takes ~1 min while measuring the assignment fidelity takes maybe 5 seconds and the 1QB RB may take 5-20 minutes. For this reason, it may not be good to lump a general `Qubit` object with all the parameters and update it after every characterization.

I have added an abstract class detailing the general parameters that can be inherited by each characterization table, so scaling up to more tables/routines should be easy.

TODO:

- [ ] Test table creation works as expected
- [ ] Add status flag to QPU object to denote active/inactive platform
- [ ] Update platform add script to be callable from CLI
- [ ] Update routine calibration scripts with new schema
- [ ] Test routine calibration works with new tables