### PR TITLE
Using len(qubits) for the y position of panels

### DIFF
--- a/grafana/grafana_configuration/templates/coherence_fidelity.json
+++ b/grafana/grafana_configuration/templates/coherence_fidelity.json
@@ -131,7 +131,7 @@
                     {% endfor %}
                 ]
             }
-            {% set ns.y_position = ns.y_position +  1 + (qubits // panels_per_row) * (panel_height_small + panel.height) + (panel_height_small + panel.height) %}
+            {% set ns.y_position = ns.y_position +  1 + (qubits|length // panels_per_row) * (panel_height_small + panel.height) + (panel_height_small + panel.height) %}
             {% if not loop.last %},{% endif %}
             {% endfor %}
         ]


### PR DESCRIPTION
The y position of panels need the number of monitored qubits.
Previously `qubits` was the number of qubits, but now it's a list of qubits.